### PR TITLE
Flag to inherit access transformers on methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ Plugin - parchment
 Plugin - accesstransformers
       --access-transformer=<atFiles>
 
+      --access-transformer-inherit-method
+                           Whether or not access transformers on methods should be inherited from
+                             parent types
       --access-transformer-validation=<validation>
                            The level of validation to use for ats
       --enable-accesstransformers

--- a/accesstransformers/src/main/java/net/neoforged/jst/accesstransformers/AccessTransformersTransformer.java
+++ b/accesstransformers/src/main/java/net/neoforged/jst/accesstransformers/AccessTransformersTransformer.java
@@ -25,6 +25,12 @@ public class AccessTransformersTransformer implements SourceTransformer {
     @CommandLine.Option(names = "--access-transformer-validation", description = "The level of validation to use for ats")
     public AccessTransformerValidation validation = AccessTransformerValidation.LOG;
 
+    @CommandLine.Option(
+        names = "--access-transformer-inherit-method",
+        description = "Whether or not access transformers on methods should be inherited from parent types"
+    )
+    public boolean inheritMethodAccessTransformers = false;
+
     private AccessTransformerFiles ats;
     private Map<Target, Transformation> pendingATs;
     private Logger logger;
@@ -64,7 +70,13 @@ public class AccessTransformersTransformer implements SourceTransformer {
 
     @Override
     public void visitFile(PsiFile psiFile, Replacements replacements) {
-        var visitor = new ApplyATsVisitor(ats, replacements, pendingATs, logger);
+        var visitor = new ApplyATsVisitor(
+            ats,
+            replacements,
+            pendingATs,
+            this.inheritMethodAccessTransformers,
+            logger
+        );
         visitor.visitFile(psiFile);
         if (visitor.errored) {
             errored = true;

--- a/tests/data/accesstransformer/methods_inheritance/accesstransformer.cfg
+++ b/tests/data/accesstransformer/methods_inheritance/accesstransformer.cfg
@@ -1,0 +1,1 @@
+public Parent flag()Z

--- a/tests/data/accesstransformer/methods_inheritance/expected/Child.java
+++ b/tests/data/accesstransformer/methods_inheritance/expected/Child.java
@@ -1,0 +1,6 @@
+class Child extends Parent {
+    @Override
+    public boolean flag() {
+        return true;
+    }
+}

--- a/tests/data/accesstransformer/methods_inheritance/expected/Grandchild.java
+++ b/tests/data/accesstransformer/methods_inheritance/expected/Grandchild.java
@@ -1,0 +1,6 @@
+class Grandchild extends Child {
+    @Override
+    public boolean flag() {
+        return false;
+    }
+}

--- a/tests/data/accesstransformer/methods_inheritance/expected/Parent.java
+++ b/tests/data/accesstransformer/methods_inheritance/expected/Parent.java
@@ -1,0 +1,5 @@
+class Parent {
+    public boolean flag() {
+        return false;
+    }
+}

--- a/tests/data/accesstransformer/methods_inheritance/source/Child.java
+++ b/tests/data/accesstransformer/methods_inheritance/source/Child.java
@@ -1,0 +1,6 @@
+class Child extends Parent {
+    @Override
+    protected boolean flag() {
+        return true;
+    }
+}

--- a/tests/data/accesstransformer/methods_inheritance/source/Grandchild.java
+++ b/tests/data/accesstransformer/methods_inheritance/source/Grandchild.java
@@ -1,0 +1,6 @@
+class Grandchild extends Child {
+    @Override
+    protected boolean flag() {
+        return false;
+    }
+}

--- a/tests/data/accesstransformer/methods_inheritance/source/Parent.java
+++ b/tests/data/accesstransformer/methods_inheritance/source/Parent.java
@@ -1,0 +1,5 @@
+class Parent {
+    protected boolean flag() {
+        return false;
+    }
+}

--- a/tests/data/accesstransformer/methods_no_inheritance/accesstransformer.cfg
+++ b/tests/data/accesstransformer/methods_no_inheritance/accesstransformer.cfg
@@ -1,0 +1,1 @@
+public Parent flag()Z

--- a/tests/data/accesstransformer/methods_no_inheritance/expected/Child.java
+++ b/tests/data/accesstransformer/methods_no_inheritance/expected/Child.java
@@ -1,0 +1,6 @@
+class Child extends Parent {
+    @Override
+    protected boolean flag() {
+        return true;
+    }
+}

--- a/tests/data/accesstransformer/methods_no_inheritance/expected/Grandchild.java
+++ b/tests/data/accesstransformer/methods_no_inheritance/expected/Grandchild.java
@@ -1,0 +1,6 @@
+class Grandchild extends Child {
+    @Override
+    protected boolean flag() {
+        return false;
+    }
+}

--- a/tests/data/accesstransformer/methods_no_inheritance/expected/Parent.java
+++ b/tests/data/accesstransformer/methods_no_inheritance/expected/Parent.java
@@ -1,0 +1,5 @@
+class Parent {
+    public boolean flag() {
+        return false;
+    }
+}

--- a/tests/data/accesstransformer/methods_no_inheritance/source/Child.java
+++ b/tests/data/accesstransformer/methods_no_inheritance/source/Child.java
@@ -1,0 +1,6 @@
+class Child extends Parent {
+    @Override
+    protected boolean flag() {
+        return true;
+    }
+}

--- a/tests/data/accesstransformer/methods_no_inheritance/source/Grandchild.java
+++ b/tests/data/accesstransformer/methods_no_inheritance/source/Grandchild.java
@@ -1,0 +1,6 @@
+class Grandchild extends Child {
+    @Override
+    protected boolean flag() {
+        return false;
+    }
+}

--- a/tests/data/accesstransformer/methods_no_inheritance/source/Parent.java
+++ b/tests/data/accesstransformer/methods_no_inheritance/source/Parent.java
@@ -1,0 +1,5 @@
+class Parent {
+    protected boolean flag() {
+        return false;
+    }
+}

--- a/tests/src/test/java/net/neoforged/jst/tests/EmbeddedTest.java
+++ b/tests/src/test/java/net/neoforged/jst/tests/EmbeddedTest.java
@@ -1,5 +1,6 @@
 package net.neoforged.jst.tests;
 
+import com.intellij.util.ArrayUtil;
 import net.neoforged.jst.cli.Main;
 import org.assertj.core.util.CanIgnoreReturnValue;
 import org.junit.jupiter.api.BeforeEach;
@@ -286,6 +287,16 @@ public class EmbeddedTest {
         void testIllegal() throws Exception {
             runATTest("illegal");
         }
+
+        @Test
+        void testMethodsNoInheritance() throws Exception {
+            runATTest("methods_no_inheritance");
+        }
+
+        @Test
+        void testMethodsInheritance() throws Exception {
+            runATTest("methods_inheritance", "--access-transformer-inherit-method");
+        }
     }
 
     @Nested
@@ -350,10 +361,15 @@ public class EmbeddedTest {
         }
     }
 
-    protected final void runATTest(String testDirName) throws Exception {
+    protected final void runATTest(String testDirName, final String... extraArgs) throws Exception {
         testDirName = "accesstransformer/" + testDirName;
         var atPath = testDataRoot.resolve(testDirName).resolve("accesstransformer.cfg");
-        runTest(testDirName, txt -> txt.replace(atPath.toAbsolutePath().toString(), "{atpath}"), "--enable-accesstransformers", "--access-transformer", atPath.toString());
+        runTest(testDirName, txt -> txt.replace(atPath.toAbsolutePath().toString(), "{atpath}"), ArrayUtil.mergeArrays(
+            new String[]{
+                "--enable-accesstransformers", "--access-transformer", atPath.toString()
+            },
+            extraArgs
+        ));
     }
 
     protected final void runParchmentTest(String testDirName, String mappingsFilename) throws Exception {


### PR DESCRIPTION
Useful for modifying methods exposed by types with a lot of children
to avoid specifying them all.